### PR TITLE
Use common tooltipOptions for all toolTips, Never display Geographic Area column

### DIFF
--- a/frontend/src/common/config.ts
+++ b/frontend/src/common/config.ts
@@ -40,7 +40,7 @@ export const tooltipOptions = {
         continue
       }
       if (key === 'RegionLabel') {
-        newValues[val] = region
+        newValues[val == null ? '' : val] = region
         continue
       }
       if (key.startsWith('Geographic Area')) {

--- a/frontend/src/common/config.ts
+++ b/frontend/src/common/config.ts
@@ -1,3 +1,8 @@
+import { formatValue } from 'vega-tooltip'
+
+const LOCALE =
+  navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language
+
 export const RESERVE_FIELDS = [
   'Region',
   'RegionLabel',
@@ -17,3 +22,61 @@ export const OPTIONS_INSET = [
   { text: 'T (top)', value: 'T' },
   { text: 'D (down)', value: 'D' }
 ]
+
+export const tooltipOptions = {
+  theme: 'dark',
+  formatTooltip: (value: any, sanitize: any) => {
+    // Create a shallow copy of the value object with formatted numbers.
+    const newValues: any = {}
+    let region
+
+    for (const [key, val] of Object.entries(value)) {
+      // Skip the 'ColorGroup' key.
+      if (key === 'ColorGroup') {
+        continue
+      }
+      if (key === 'Region') {
+        region = val
+        continue
+      }
+      if (key === 'RegionLabel') {
+        newValues[val] = region
+        continue
+      }
+      if (key.startsWith('Geographic Area')) {
+        newValues['Area'] =
+          new Intl.NumberFormat(LOCALE, {
+            notation: 'compact',
+            compactDisplay: 'short',
+            maximumFractionDigits: 3
+          }).format(val) + ' km²'
+        continue
+      }
+      // Check if value is null or undefined.
+      if (val == null) {
+        continue
+      }
+      const num = Number(val)
+      if (!isNaN(num)) {
+        let unit = ''
+        const baseKey = key
+          .replace(/\s*\(([^)]+)\)/, (_, p1) => {
+            unit = ' ' + p1
+            return ''
+          })
+          .trim()
+        newValues[baseKey] =
+          new Intl.NumberFormat(LOCALE, {
+            notation: 'compact',
+            compactDisplay: 'short',
+            maximumFractionDigits: 3
+          }).format(num) + unit
+      } else {
+        newValues[key] = val
+      }
+    }
+
+    // Delegate to the default formatter to keep their HTML structure.
+    return formatValue(newValues, sanitize, 0)
+  }
+}

--- a/frontend/src/maker/components/CDataTable.vue
+++ b/frontend/src/maker/components/CDataTable.vue
@@ -38,13 +38,6 @@ watch(
 )
 
 watch(
-  () => props.useEqualArea,
-  () => {
-    state.dataTable.fields[config.COL_AREA].show = props.useEqualArea
-  }
-)
-
-watch(
   () => props.useInset,
   () => {
     state.dataTable.fields[config.COL_INSET].show = props.useInset
@@ -81,7 +74,7 @@ function reset() {
       type: 'text',
       editable: true,
       editableHead: true,
-      show: true
+      show: false
     }
   ]
   state.displayTable = false
@@ -227,7 +220,6 @@ function updateDataTable(csvData: KeyValueArray) {
   )
   state.dataTable.fields.splice(config.NUM_RESERVED_FILEDS)
   state.dataTable.fields[config.COL_COLOR].show = csvData[0].hasOwnProperty('Color')
-  state.dataTable.fields[config.COL_AREA].show = csvData[0].hasOwnProperty('Geographic Area')
   state.dataTable.fields[config.COL_INSET].show = csvData[0].hasOwnProperty('Inset')
   initDataTableWArray(csvData, false)
 

--- a/frontend/src/maker/components/CDataTable.vue
+++ b/frontend/src/maker/components/CDataTable.vue
@@ -149,7 +149,8 @@ async function initDataTableWArray(data: KeyValueArray, isReplace = true) {
 
   const container = await embed('#map-vis', <VisualizationSpec>versionSpec, {
     renderer: 'svg',
-    actions: false
+    actions: false,
+    tooltip: config.tooltipOptions
   })
   visView = container.view
   if (props.mapColorScheme !== 'custom')
@@ -427,24 +428,6 @@ table input[type='color'] {
 .cell-content {
   position: relative;
   display: inline-block;
-}
-
-/* Tooltip styling */
-.tooltip {
-  visibility: hidden;
-  background-color: #333;
-  color: #fff;
-  text-align: left;
-  padding: 4px;
-  border-radius: 4px;
-  position: absolute;
-  z-index: 10;
-  left: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  white-space: nowrap;
-  opacity: 0;
-  transition: opacity 0s;
 }
 
 /* Show tooltip immediately on hover */

--- a/frontend/src/viewer/components/CPanelLegend.vue
+++ b/frontend/src/viewer/components/CPanelLegend.vue
@@ -6,7 +6,8 @@
 import { onMounted, nextTick, reactive, ref, watch, inject } from 'vue'
 import * as d3 from 'd3'
 import embed, { type VisualizationSpec } from 'vega-embed'
-import { formatValue } from 'vega-tooltip'
+
+import * as config from '../../common/config'
 
 import * as util from '../lib/util'
 
@@ -118,54 +119,10 @@ onMounted(async () => {
 
   visEl = d3.select('#' + props.panelID + '-vis')
   offscreenEl = d3.select('#' + props.panelID + '-offscreen')
-  const tooltipOptions = {
-    theme: 'dark',
-    formatTooltip: (value: any, sanitize: any) => {
-      // Create a shallow copy of the value object with formatted numbers.
-      const newValues: any = {}
-      let region
-
-      for (const [key, val] of Object.entries(value)) {
-        // Skip the 'ColorGroup' key.
-        if (key === 'ColorGroup') {
-          continue
-        }
-        if (key === 'Region') {
-          region = val
-          continue
-        }
-        if (key === 'RegionLabel') {
-          newValues[val] = region
-          continue
-        }
-        const num = Number(val)
-        if (!isNaN(num)) {
-          let unit = ''
-          const baseKey = key
-            .replace(/\s*\(([^)]+)\)/, (_, p1) => {
-              unit = ' ' + p1
-              return ''
-            })
-            .trim()
-          newValues[baseKey] =
-            new Intl.NumberFormat(LOCALE, {
-              notation: 'compact',
-              compactDisplay: 'short',
-              maximumFractionDigits: 3
-            }).format(num) + unit
-        } else {
-          newValues[key] = val
-        }
-      }
-
-      // Delegate to the default formatter to keep their HTML structure.
-      return formatValue(newValues, sanitize, 0)
-    }
-  }
   const container = await embed('#' + props.panelID + '-vis', <VisualizationSpec>versionSpec, {
     renderer: 'svg',
     actions: false,
-    tooltip: tooltipOptions
+    tooltip: config.tooltipOptions
   })
   visView = container.view
 

--- a/frontend/src/viewer/components/CPanelLegend.vue
+++ b/frontend/src/viewer/components/CPanelLegend.vue
@@ -162,7 +162,7 @@ async function switchVersion() {
   const container = await embed(
     '#' + props.panelID + '-offscreen',
     <VisualizationSpec>versionSpec,
-    { renderer: 'svg', actions: false }
+    { renderer: 'svg', actions: false, tooltip: config.tooltipOptions }
   )
   const [area, sum] = util.getTotalAreasAndValuesForVersion(
     state.version.header,


### PR DESCRIPTION
A small note: I didn't end up implementing the `delete` for the `Color` and `Inset` properties. I deal with these by checking if the values are null in the `tooltipOptions`. I'm not sure if it is worth it or not.

Another thing yet to implement: in the CSV download, we should remove the Geographic Area column. I have just realised this. Plus, if Inset is on, we should fill it with "C (Center)" by default. I will send in a new pull request for those two, but I think they are less important just yet, so it should do for now.