### PR TITLE
feat: Round total and tooltip variables to 3 significant figures

### DIFF
--- a/frontend/src/common/lib/tooltipOptions.ts
+++ b/frontend/src/common/lib/tooltipOptions.ts
@@ -36,7 +36,8 @@ export const tooltipOptions = {
           new Intl.NumberFormat(LOCALE, {
             notation: 'compact',
             compactDisplay: 'short',
-            maximumFractionDigits: 3
+            minimumSignificantDigits: 3,
+            maximumSignificantDigits: 3
           }).format(num) + unit
       }
     }

--- a/frontend/src/viewer/composables/useAreaLegend.ts
+++ b/frontend/src/viewer/composables/useAreaLegend.ts
@@ -55,7 +55,7 @@ export const useAreaLegend = () => {
 
     const totalScalePowerOfTen = Math.floor(Math.log10(totalValue))
     const totalNiceNumber = totalValue / Math.pow(10, totalScalePowerOfTen)
-    stateTotalValue.value = _formatLegendText(totalNiceNumber, totalScalePowerOfTen)
+    stateTotalValue.value = _formatLegendText(totalNiceNumber, totalScalePowerOfTen, 3, 3)
   }
 
   const updateLegendValue = (gridIndex: number, affineScale: Array<number>) => {
@@ -113,12 +113,24 @@ export const useAreaLegend = () => {
     valueScalePowerOf10 = scalePowerOf10
   }
 
-  const _formatLegendText = (value: number, scalePowerOf10: number): string => {
+  const _formatLegendText = (
+    value: number,
+    scalePowerOf10: number,
+    minSigDigits?: number,
+    maxSigDigits?: number
+  ): string => {
     const originalValue = value * Math.pow(10, scalePowerOf10)
-    const formatter = Intl.NumberFormat(config.LOCALE, {
+    const formatterOptions: Intl.NumberFormatOptions = {
       notation: 'compact',
       compactDisplay: 'short'
-    })
+    }
+    if (minSigDigits !== undefined) {
+      formatterOptions.minimumSignificantDigits = minSigDigits
+    }
+    if (maxSigDigits !== undefined) {
+      formatterOptions.maximumSignificantDigits = maxSigDigits
+    }
+    const formatter = Intl.NumberFormat(config.LOCALE, formatterOptions)
     let formated = ''
     formated += formatter.format(originalValue)
     return formated

--- a/internal/carto/boundary.py
+++ b/internal/carto/boundary.py
@@ -70,8 +70,8 @@ def preprocess(input, mapDBKey="temp_filename"):
 
     # Fill in attributes
     if not any(cdf.columns.str.startswith("Geographic Area")):
-        cdf["Geographic Area (sq. km)"] = round(tmp_cdf.area / 10**6)
-        cdf["Geographic Area (sq. km)"] = cdf["Geographic Area (sq. km)"].astype(int)
+        cdf["Geographic Area (sq. km)"] = tmp_cdf.area / 10**6
+        cdf["Geographic Area (sq. km)"] = cdf["Geographic Area (sq. km)"].astype(float)
 
     if "ColorGroup" not in cdf.columns:
         cdf["ColorGroup"] = assign_colors(tmp_cdf)


### PR DESCRIPTION
Previously, the total variable was potentially rounded to a single significant figure, whereas the tooltip value had many more figures. The new version uses consistently three significant figures for both.