### PR TITLE
Fix noncontiguous cartogram legend total and grid

### DIFF
--- a/frontend/src/viewer/components/CPanel.vue
+++ b/frontend/src/viewer/components/CPanel.vue
@@ -89,18 +89,11 @@ async function initContainer(canvasId: string) {
     CARTOGRAM_CONFIG.choroSpec
   )
 
-  if (CARTOGRAM_CONFIG.cartoVersions[state.versionKey].type === 'noncontiguous')
-    areaLegend.init(
-      CARTOGRAM_CONFIG.cartoVersions['0'].header,
-      visAreaEl.value.view().data('equal_area_geojson'),
-      visAreaEl.value.view().data('source_csv')
-    )
-  else
-    areaLegend.init(
-      CARTOGRAM_CONFIG.cartoVersions[state.versionKey].header,
-      visAreaEl.value.view().data('geo_1'),
-      visAreaEl.value.view().data('source_csv')
-    )
+  areaLegend.init(
+    CARTOGRAM_CONFIG.cartoVersions[state.versionKey].header,
+    visAreaEl.value.view().data('geo_1'),
+    visAreaEl.value.view().data('source_csv')
+  )
 }
 
 async function init() {
@@ -138,6 +131,11 @@ async function switchVersion(versionKey: string) {
 
 async function switchGrid(key: number) {
   state.currentGridIndex = key
+  let currentGridOpacity =
+    CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type === 'noncontiguous'
+      ? 0
+      : store.options.gridOpacity
+
   areaLegend.updateGridData()
   await nextTick()
   visAreaEl.value.transform.setGridScaleNiceNumber(
@@ -148,7 +146,11 @@ async function switchGrid(key: number) {
     visAreaEl.value.transform.stateAffineScale.value
   )
   legendLineEl.value.setHandlePosition(areaLegend.stateGridData.value[key]?.width)
-  animate.gridTransition(props.panelID + '-grid', areaLegend.stateGridData.value[key]?.width)
+  animate.gridTransition(
+    props.panelID + '-grid',
+    areaLegend.stateGridData.value[key]?.width,
+    currentGridOpacity
+  )
 }
 </script>
 
@@ -192,12 +194,7 @@ async function switchGrid(key: number) {
           <svg width="100%" height="100%" v-bind:id="props.panelID + '-grid-area'">
             <defs>
               <pattern v-bind:id="props.panelID + '-grid'" patternUnits="userSpaceOnUse">
-                <path
-                  fill="none"
-                  stroke="#5A5A5A"
-                  stroke-width="2"
-                  v-bind:stroke-opacity="store.options.gridOpacity"
-                ></path>
+                <path fill="none" stroke="#5A5A5A" stroke-width="2"></path>
               </pattern>
             </defs>
             <rect

--- a/frontend/src/viewer/components/CPanel.vue
+++ b/frontend/src/viewer/components/CPanel.vue
@@ -129,7 +129,7 @@ async function init() {
 }
 
 function getCurrentGridOpacity() {
-  return isNoncontiguous ? 0 : store.options.gridOpacity
+  return isNoncontiguous.value ? 0 : store.options.gridOpacity
 }
 
 async function switchVersion(versionKey: string) {

--- a/frontend/src/viewer/components/CPanel.vue
+++ b/frontend/src/viewer/components/CPanel.vue
@@ -50,6 +50,15 @@ watch(
 )
 
 watch(
+  () => store.options.gridOpacity,
+  async () => {
+    let currentGridOpacity = getCurrentGridOpacity()
+    const gridPattern = document.getElementById(props.panelID + '-grid')
+    gridPattern?.setAttribute('stroke-opacity', currentGridOpacity.toString())
+  }
+)
+
+watch(
   () => store.currentColorCol,
   () => {
     init()
@@ -115,6 +124,12 @@ async function init() {
   })
 }
 
+function getCurrentGridOpacity() {
+  return CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type === 'noncontiguous'
+    ? 0
+    : store.options.gridOpacity
+}
+
 async function switchVersion(versionKey: string) {
   state.versionKey = versionKey
   await initContainer(props.panelID + '-offscreen')
@@ -131,10 +146,7 @@ async function switchVersion(versionKey: string) {
 
 async function switchGrid(key: number) {
   state.currentGridIndex = key
-  let currentGridOpacity =
-    CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type === 'noncontiguous'
-      ? 0
-      : store.options.gridOpacity
+  let currentGridOpacity = getCurrentGridOpacity()
 
   areaLegend.updateGridData()
   await nextTick()

--- a/frontend/src/viewer/components/CPanel.vue
+++ b/frontend/src/viewer/components/CPanel.vue
@@ -2,7 +2,7 @@
 /**
  * The map panel with functions for interactivity to manipulate viewport and managing grid size.
  */
-import { onMounted, nextTick, reactive, watch, ref } from 'vue'
+import { onMounted, nextTick, reactive, watch, ref, computed } from 'vue'
 
 import CVisualizationArea from '@/common/components/CVisualizationArea.vue'
 
@@ -65,6 +65,10 @@ watch(
   }
 )
 
+const isNoncontiguous = computed(() => {
+  return CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type === 'noncontiguous'
+})
+
 onMounted(async () => {
   await init()
   switchGrid(state.currentGridIndex)
@@ -125,9 +129,7 @@ async function init() {
 }
 
 function getCurrentGridOpacity() {
-  return CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type === 'noncontiguous'
-    ? 0
-    : store.options.gridOpacity
+  return isNoncontiguous ? 0 : store.options.gridOpacity
 }
 
 async function switchVersion(versionKey: string) {
@@ -170,22 +172,20 @@ async function switchGrid(key: number) {
   <div class="card w-100">
     <div class="d-flex flex-column card-body">
       <div class="d-flex flex-column card-body p-0">
-        <div
-          class="position-absolute z-1"
-          v-bind:class="{
-            'd-flex': CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type !== 'noncontiguous',
-            'd-none': CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.type === 'noncontiguous'
-          }"
-        >
+        <div class="d-flex position-absolute z-1">
           <c-panel-legend
             ref="legendLineEl"
             v-bind:panelID="props.panelID"
             v-bind:gridIndex="state.currentGridIndex"
             v-bind:gridData="areaLegend.stateGridData.value"
             v-on:change="switchGrid"
+            v-bind:class="{
+              'd-flex': !isNoncontiguous,
+              'd-none': isNoncontiguous
+            }"
           />
           <div v-bind:id="props.panelID + '-legend-text'" class="flex-fill p-1">
-            <div v-bind:id="props.panelID + '-legend-num'">
+            <div v-if="!isNoncontiguous" v-bind:id="props.panelID + '-legend-num'">
               <span v-html="areaLegend.stateValue.value"></span>
               {{ CARTOGRAM_CONFIG.cartoVersions[state.versionKey]?.unit }}
             </div>

--- a/frontend/src/viewer/components/CPanelLegend.vue
+++ b/frontend/src/viewer/components/CPanelLegend.vue
@@ -63,45 +63,47 @@ function onHandleUp(event: any) {
 </script>
 
 <template>
-  <svg
-    v-if="props.gridData[config.NUM_GRID_OPTIONS]"
-    ref="legendSvgEl"
-    class="d-flex position-absolute z-2"
-    style="cursor: pointer; top: -15px; touch-action: none"
-    height="30px"
-    stroke="#AAAAAA"
-    stroke-width="2px"
-    v-bind:id="props.panelID + '-slider'"
-    v-bind:width="props.gridData[config.NUM_GRID_OPTIONS].width + 15"
-    v-on:pointerdown.stop.prevent="onHandleDown"
-    v-on:pointermove.stop.prevent="onHandleMove"
-    v-on:pointerup.stop.prevent="onHandleUp"
-  >
-    <line x1="0" y1="15" v-bind:x2="props.gridData[config.NUM_GRID_OPTIONS].width" y2="15"></line>
-    <line
-      v-for="(grid, index) in props.gridData"
-      v-bind:x1="grid.width"
-      y1="8"
-      v-bind:x2="grid.width"
-      y2="16"
-      v-bind:key="index"
-    ></line>
-    <circle id="handle" r="5" v-bind:cx="state.handlePosition" cy="15" stroke-width="0px" />
-  </svg>
-  <svg
-    v-if="props.gridData[config.NUM_GRID_OPTIONS]"
-    v-bind:id="props.panelID + '-legend'"
-    style="cursor: pointer; opacity: 0.5"
-    v-bind:width="props.gridData[gridIndex].width + 2"
-    v-bind:height="props.gridData[gridIndex].width + 2"
-  >
-    <g stroke-width="2px" fill="#EEEEEE" stroke="#AAAAAA">
-      <rect
-        x="1"
-        y="1"
-        v-bind:width="props.gridData[gridIndex].width"
-        v-bind:height="props.gridData[gridIndex].width"
-      ></rect>
-    </g>
-  </svg>
+  <div>
+    <svg
+      v-if="props.gridData[config.NUM_GRID_OPTIONS]"
+      ref="legendSvgEl"
+      class="d-flex position-absolute z-2"
+      style="cursor: pointer; top: -15px; touch-action: none"
+      height="30px"
+      stroke="#AAAAAA"
+      stroke-width="2px"
+      v-bind:id="props.panelID + '-slider'"
+      v-bind:width="props.gridData[config.NUM_GRID_OPTIONS].width + 15"
+      v-on:pointerdown.stop.prevent="onHandleDown"
+      v-on:pointermove.stop.prevent="onHandleMove"
+      v-on:pointerup.stop.prevent="onHandleUp"
+    >
+      <line x1="0" y1="15" v-bind:x2="props.gridData[config.NUM_GRID_OPTIONS].width" y2="15"></line>
+      <line
+        v-for="(grid, index) in props.gridData"
+        v-bind:x1="grid.width"
+        y1="8"
+        v-bind:x2="grid.width"
+        y2="16"
+        v-bind:key="index"
+      ></line>
+      <circle id="handle" r="5" v-bind:cx="state.handlePosition" cy="15" stroke-width="0px" />
+    </svg>
+    <svg
+      v-if="props.gridData[config.NUM_GRID_OPTIONS]"
+      v-bind:id="props.panelID + '-legend'"
+      style="cursor: pointer; opacity: 0.5"
+      v-bind:width="props.gridData[gridIndex].width + 2"
+      v-bind:height="props.gridData[gridIndex].width + 2"
+    >
+      <g stroke-width="2px" fill="#EEEEEE" stroke="#AAAAAA">
+        <rect
+          x="1"
+          y="1"
+          v-bind:width="props.gridData[gridIndex].width"
+          v-bind:height="props.gridData[gridIndex].width"
+        ></rect>
+      </g>
+    </svg>
+  </div>
 </template>

--- a/frontend/src/viewer/components/CartogramViewer.vue
+++ b/frontend/src/viewer/components/CartogramViewer.vue
@@ -21,6 +21,12 @@ const state = reactive({
 onBeforeMount(() => {
   store.currentMapName = CARTOGRAM_CONFIG.mapName ? CARTOGRAM_CONFIG.mapName : ''
 
+  // Get default opacity
+  let hasNoncontiguous = Object.values(CARTOGRAM_CONFIG.cartoVersions).some(
+    (version) => version.type === 'noncontiguous'
+  )
+  if (hasNoncontiguous) store.options.gridOpacity = 0
+
   // Get default color from query string
   const urlParams = new URLSearchParams(window.location.search)
   const defaultBy = urlParams.get('by')

--- a/frontend/src/viewer/components/CartogramViewer.vue
+++ b/frontend/src/viewer/components/CartogramViewer.vue
@@ -21,12 +21,6 @@ const state = reactive({
 onBeforeMount(() => {
   store.currentMapName = CARTOGRAM_CONFIG.mapName ? CARTOGRAM_CONFIG.mapName : ''
 
-  // Get default opacity
-  let hasNoncontiguous = Object.values(CARTOGRAM_CONFIG.cartoVersions).some(
-    (version) => version.type === 'noncontiguous'
-  )
-  if (hasNoncontiguous) store.options.gridOpacity = 0
-
   // Get default color from query string
   const urlParams = new URLSearchParams(window.location.search)
   const defaultBy = urlParams.get('by')

--- a/frontend/src/viewer/lib/animate.ts
+++ b/frontend/src/viewer/lib/animate.ts
@@ -78,7 +78,7 @@ function createTransition(
     })
 }
 
-export function gridTransition(id: string, gridWidth: number) {
+export function gridTransition(id: string, gridWidth: number, gridOpacity: number) {
   const gridPattern = d3.select('#' + id)
   if (isNaN(gridWidth) || !gridPattern) return
 
@@ -93,7 +93,11 @@ export function gridTransition(id: string, gridWidth: number) {
       .duration(1000)
       .attr('width', gridWidth)
       .attr('height', gridWidth)
+      .attr('stroke-opacity', gridOpacity)
   } else {
-    gridPattern.attr('width', gridWidth).attr('height', gridWidth)
+    gridPattern
+      .attr('width', gridWidth)
+      .attr('height', gridWidth)
+      .attr('stroke-opacity', gridOpacity)
   }
 }


### PR DESCRIPTION
As discussed in https://github.com/go-cart-io/cartogram-web/pull/51, this PR introduces the following changes:
- Uses the data column in the area legend instead of the geographic area.
- Displays the total of data values for noncontiguous cartograms in the web UI.
- Sets the grid opacity of noncontiguous cartograms to 0.
- Automatically sets the default grid opacity to 0 whenever any data column uses a noncontiguous visualization.
- Allows users to adjust grid opacity for all map types except noncontiguous cartograms.