### PR TITLE
Use gtag.js consent mode for Google Analytics tracking

### DIFF
--- a/internal/static/tracking.js
+++ b/internal/static/tracking.js
@@ -47,42 +47,14 @@ class TrackingHTTP {
   }
 }
 
-class TrackingDynamicLoading {
-  /**
-   * Loads a script and performs an action upon load
-   * @param url The URL of the script
-   * @param implementationCode The function to be run after loading
-   * @param location The element to assign the script tag to
-   */
-  static loadScript(url, implementationCode, location) {
-    let scriptTag = document.createElement("script");
-    scriptTag.src = url;
-
-    scriptTag.onload = implementationCode;
-    scriptTag.onreadystatechange = implementationCode;
-
-    location.appendChild(scriptTag);
-  }
-}
-
 class Tracking {
   /**
-   * Load the Google Analytics tracking script
-   * @param tracking_id The GA tracking ID
+   * Enable Google Analytics storage
    */
-  static beginTracking(tracking_id) {
-    TrackingDynamicLoading.loadScript(
-      "https://www.googletagmanager.com/gtag/js?id=" + tracking_id,
-      () => {
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = function () {
-          window.dataLayer.push(arguments);
-        };
-        window.gtag("js", new Date());
-        window.gtag("config", tracking_id);
-      },
-      document.head
-    );
+  static beginTracking() {
+      gtag("consent", "update", {
+        "analytics_storage": "granted"        	  
+      });
   }
 
   static consentToTracking() {
@@ -92,7 +64,7 @@ class Tracking {
     TrackingHTTP.post("/api/v1/consent", form).then(
       (response) => {
         document.getElementById("cookie-consent").style.display = "none";
-        Tracking.beginTracking(response.tracking_id);
+        Tracking.beginTracking();
       },
       (err) => console.log(err)
     );

--- a/internal/templates/base_layout.html
+++ b/internal/templates/base_layout.html
@@ -2,6 +2,29 @@
 <html lang="en">
 
 <head>
+
+  <!-- Google Analytics tracking code -->
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+
+    gtag("consent", "default", {
+         "ad_storage": "denied",
+         "ad_user_data": "denied",
+         "ad_personalization": "denied",
+         "analytics_storage": "denied",
+         "wait_for_update": 500
+    });
+  </script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ tracking.tracking_id }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+
+    gtag("js", new Date());
+    gatg("config", "{{ tracking.tracking_id }}");
+  </script>
+  
   {% include 'header.html' %}
 
   <script src="{{ url_for('static', filename='tracking.js') }}"></script>
@@ -95,7 +118,7 @@
 
   {% elif tracking.action == "track" %}
 
-  <script>Tracking.beginTracking("{{ tracking.tracking_id }}");</script>
+  <script>Tracking.beginTracking();</script>
 
   {% endif %}
 

--- a/internal/views/tracking.py
+++ b/internal/views/tracking.py
@@ -43,10 +43,19 @@ def determine_tracking_action(request):
     tracking_setting = request.cookies.get("tracking")
 
     if tracking_setting is None:
-        return {"action": "demand_consent"}
+        return {
+            "action": "demand_consent",
+            "tracking_id": settings.CARTOGRAM_GA_TRACKING_ID
+        }
 
     elif tracking_setting == "track":
-        return {"action": "track", "tracking_id": settings.CARTOGRAM_GA_TRACKING_ID}
+        return {
+            "action": "track",
+            "tracking_id": settings.CARTOGRAM_GA_TRACKING_ID
+        }
 
     else:
-        return {"action": "do_not_track"}
+        return {
+            "action": "do_not_track",
+            "tracking_id": settings.CARTOGRAM_GA_TRACKING_ID
+        }


### PR DESCRIPTION
Previously, go-cart.io loaded the gtag.js script to enable Google Analytics tracking only after users consent to use of performance cookies. Google now recommends use of consent mode to manage cookies created during Google Analytics tracking. With consent mode, the tracking and consent workflow changes slightly:

1. The gtag.js script is now _always_ initialized with the configured tag ID.
2. By default, `analytics_storage` consent, along with other third-party advertising cookie consent, is `denied`.
3. If users accept use of performance cookies by clicking 'Accept' (or when this setting is remembered), `analytics_storage` consent is updated to `granted`.

For more information on gtag.js consent mode, see the [Google Tag Platform documentation](https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced).