### PR TITLE
feat: Auto-repair invalid geometries on upload

### DIFF
--- a/internal/carto/dataframe.py
+++ b/internal/carto/dataframe.py
@@ -1,8 +1,10 @@
 import json
+import warnings
 from typing import Any
 
 import geopandas as gpd
 from errors import CartoError
+from shapely.validation import make_valid
 from utils import file_utils
 
 
@@ -117,10 +119,27 @@ class CartoDataFrame(gpd.GeoDataFrame):
                 raise CartoError(
                     "TopoJSON is not fully supported. Please convert your file to GeoJSON and try again."
                 )
-            else:
+
+            # Auto-fix invalid/non-simple geometries using Shapely's make_valid
+            invalid_mask = ~gdf.is_simple
+            invalid_count = invalid_mask.sum()
+            gdf.loc[invalid_mask, "geometry"] = gdf.loc[
+                invalid_mask, "geometry"
+            ].apply(make_valid)
+
+            # Verify the fix worked
+            if not gdf.is_simple.all():
                 raise CartoError(
-                    "Geometries are not simple. Fix the boundary file and try again."
+                    "Geometries are not simple and could not be automatically repaired. "
+                    "Fix the boundary file and try again."
                 )
+
+            warnings.warn(
+                f"Invalid geometry detected: {invalid_count} geometry(ies) had "
+                f"self-intersections or other issues and were automatically repaired.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         return cls(gdf, extra_attributes=extra_attributes)
 

--- a/internal/routes/api_routes.py
+++ b/internal/routes/api_routes.py
@@ -92,6 +92,13 @@ def cartogram_preprocess(mapDBKey):
                     "Multiple map layers found. If the preview isn't what you expected, please remove unwanted map layers and re-upload your boundary file."
                 )
 
+            elif "Invalid geometry detected" in str(warning_message.message):
+                processed_geojson["warnings"].append(
+                    "Invalid geometry detected in your boundary file. "
+                    "Self-intersections and other issues were automatically repaired. "
+                    "Please verify the map preview looks correct."
+                )
+
     current_app.logger.info(f"Finish preprocessing map for {mapDBKey}")
     return Response(
         json.dumps(processed_geojson),

--- a/internal/tests/test_carto_dataframe.py
+++ b/internal/tests/test_carto_dataframe.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from carto.dataframe import CartoDataFrame
 
@@ -58,3 +59,41 @@ def test_clean_properties_with_other_region_column(test_data_dir):
     assert "Region" in carto_json["features"][0]["properties"]
     assert "99" == carto_json["features"][0]["properties"]["Region"]
     assert "prop_non_unique" not in carto_json["features"][0]["properties"]
+
+
+def test_invalid_geometry_auto_repair(test_data_dir):
+    """Test that invalid (self-intersecting) geometries are automatically repaired with a warning."""
+    geojson_file = test_data_dir / "invalid_geometry.geojson"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        carto_df = CartoDataFrame.read_file(str(geojson_file))
+
+        # Should have emitted a warning about invalid geometry
+        geometry_warnings = [
+            x for x in w if "Invalid geometry detected" in str(x.message)
+        ]
+        assert len(geometry_warnings) == 1
+        assert "1 geometry(ies)" in str(geometry_warnings[0].message)
+        assert "automatically repaired" in str(geometry_warnings[0].message)
+
+    # The resulting dataframe should have valid, simple geometries
+    assert isinstance(carto_df, CartoDataFrame)
+    assert carto_df.is_simple.all()
+    assert len(carto_df) == 2
+
+
+def test_valid_geometry_no_warning(test_data_dir):
+    """Test that valid geometries don't trigger any geometry repair warning."""
+    geojson_file = test_data_dir / "usa_by_state_since_1959.geojson"
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        carto_df = CartoDataFrame.read_file(str(geojson_file))
+
+        geometry_warnings = [
+            x for x in w if "Invalid geometry detected" in str(x.message)
+        ]
+        assert len(geometry_warnings) == 0
+
+    assert isinstance(carto_df, CartoDataFrame)

--- a/test-data/invalid_geometry.geojson
+++ b/test-data/invalid_geometry.geojson
@@ -1,0 +1,43 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [0.0, 0.0],
+            [2.0, 2.0],
+            [2.0, 0.0],
+            [0.0, 2.0],
+            [0.0, 0.0]
+          ]
+        ]
+      },
+      "properties": {
+        "Region": "Bowtie",
+        "cartogram_id": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [3.0, 0.0],
+            [5.0, 0.0],
+            [5.0, 2.0],
+            [3.0, 2.0],
+            [3.0, 0.0]
+          ]
+        ]
+      },
+      "properties": {
+        "Region": "Valid",
+        "cartogram_id": 2
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Re-submission of #57 (which was merged then reverted).

## Summary
- Invalid (self-intersecting) geometries are now auto-repaired using Shapely's `make_valid` instead of failing
- A warning is shown to the user so they can verify the map preview
- If repair fails, the original error is still raised

## Files changed
- `internal/carto/dataframe.py` — detect and repair invalid geometries
- `internal/routes/api_routes.py` — surface warning to frontend
- `internal/tests/test_carto_dataframe.py` — test with bowtie polygon fixture
- `test-data/invalid_geometry.geojson` — test fixture

## Testing
- [x] Tested invalid_geometry.geojson — repaired with warning
- [x] Tested invalid geometry of Singapore provided by data.gov.sg at https://data.gov.sg/datasets/d_4765db0e87b9c86336792efe8a1f7a66/view - works fine on this branch, does not work on the website currently (this is what originally sparked us wanting to create this issue)
- [x] Upload a valid GeoJSON — no warning, works as before