### PR TITLE
fix: Handle label column already parsed as dict in clean_properties

### DIFF
--- a/internal/carto/dataframe.py
+++ b/internal/carto/dataframe.py
@@ -213,4 +213,6 @@ class CartoDataFrame(gpd.GeoDataFrame):
         )
 
         if "label" in self.columns:
-            self["label"] = self["label"].apply(json.loads)
+            self["label"] = self["label"].apply(
+                lambda x: x if isinstance(x, dict) else json.loads(x)
+            )


### PR DESCRIPTION
## Summary
- Fixes a `TypeError: the JSON object must be str, bytes or bytearray, not dict` crash in `clean_properties`
- Occurs when a user uploads a GeoJSON file that was previously generated by the cartogram tool (e.g. `Geographic Area.json` or cartogram output), where the `label` property is stored as a JSON object
- GeoPandas parses such properties into Python `dict`s; the previous `json.loads` call rejected anything that was already a dict
- The fix guards the call so already-parsed dicts are passed through unchanged

## Root cause
`clean_properties` in `dataframe.py` unconditionally applies `json.loads` to the `label` column. When the input file already has `label` as a parsed object (not a JSON string), this raises `TypeError`.

## Files changed
- `internal/carto/dataframe.py` — guard `json.loads` call in `clean_properties`

## Testing
- [ ] Upload a previously-generated cartogram GeoJSON (containing `label` as an object) — should succeed without error
- [ ] Upload a normal GeoJSON without `label` — no change in behaviour
- [ ] Upload a GeoJSON where `label` is stored as a JSON string — still parsed correctly